### PR TITLE
Remove a bad whitespace from an expression

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -48,7 +48,7 @@
         "testcases":[
 
             [ "{/id*}" , ["/person/albums","/albums/person"] ],
-            [ "{/id*}{?fields, token}" , [ 
+            [ "{/id*}{?fields,token}" , [ 
             	"/person/albums?fields=id,name,picture&token=12345",
             	"/person/albums?fields=id,picture,name&token=12345",
             	"/person/albums?fields=picture,name,id&token=12345",


### PR DESCRIPTION
Hi

this expression from the extended tests is broken:

```
"{/id*}{?fields, token}"
```

Expression are not allowed to contain whitespace according to [section 2.2](http://tools.ietf.org/html/rfc6570#section-2.2) and [section 2.3](http://tools.ietf.org/html/rfc6570#section-2.3)

Thank you
Hannes
