### PR TITLE
Added an example with special characters in an associative array

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -20,8 +20,9 @@
             "query"        : "PREFIX dc: <http://purl.org/dc/elements/1.1/> SELECT ?book ?who WHERE { ?book dc:creator ?who }",
             "word"         : "drücken",
             "Stra%C3%9Fe"  : "Grüner Weg",
-            "random"       : "šöäŸœñê€£¥‡ÑÒÓÔÕÖ×ØÙÚàáâãäåæçÿ"
-            
+            "random"       : "šöäŸœñê€£¥‡ÑÒÓÔÕÖ×ØÙÚàáâãäåæçÿ",
+            "assoc_special_chars"  :
+              { "šöäŸœñê€£¥‡ÑÒÓÔÕ" : "Ö×ØÙÚàáâãäåæçÿ" }
         },
         "testcases":[
 
@@ -45,7 +46,8 @@
             ["/sparql{?query}", "/sparql?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20SELECT%20%3Fbook%20%3Fwho%20WHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D"],
             ["/service{?word}", "/service?word=dr%C3%BCcken"],
             ["/lookup{?Stra%C3%9Fe}", "/lookup?Stra%C3%9Fe=Gr%C3%BCner%20Weg"],
-            ["{random}" , "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"]
+            ["{random}" , "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"],
+            ["{?assoc_special_chars*}", "?%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95=%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF"]
         ]
     },
     "Additional Examples 2":{


### PR DESCRIPTION
Hi,

I added one more example. I'm only 95% sure on whether it's correct, but I guess the array keys have to be escaped as shown in the example according to ( http://tools.ietf.org/html/rfc6570#section-3.2.1 ):

```
For a variable that is an associative array, expansion depends on
both the expression type and the presence of an explode modifier. [...]
If there is an explode modifier, expansion consists
of appending each pair that has a defined value as either
"name=value" or, if the value is the empty string and the expression
type does not indicate form-style parameters (i.e., not a "?" or "&"
type), simply "name".  Both name and value strings are encoded in the
same way as simple string values.
```

Thank you
Hannes
