### PR TITLE
Added some testcases for an empty list and empty associative arrays

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -79,5 +79,19 @@
             	"/albums/person?fields=name,id,picture&token=12345"]
             	]
         ]
+    },
+    "Additional Examples 3: Empty Variables":{
+        "variables" : {
+            "empty_list" : [],
+            "empty_assoc" : {}
+        },
+        "testcases":[
+            [ "{/empty_list}", [ "" ] ],
+            [ "{/empty_list*}", [ "" ] ],
+            [ "{?empty_list}", [ "?empty_list="] ],
+            [ "{?empty_list*}", [ "" ] ],
+            [ "{?empty_assoc}", [ "?empty_assoc=" ] ],
+            [ "{?empty_assoc*}", [ "" ] ]
+        ]
     }
 }


### PR DESCRIPTION
Hi

the title says all. The RFC mentions only one example and is not very verbose about the handling of empty lists and assocs.

Thank you
Hannes
