### PR TITLE
Removed tests that do not contain expressions

### DIFF
--- a/negative-tests.json
+++ b/negative-tests.json
@@ -36,16 +36,14 @@
             [ "x{?empty|foo=none}" , false ],
             [ "/h{#hello+}" , false ],
             [ "/h#{hello+}" , false ],
-            [ "/vars/:var" , false ],
             [ "{keys:1}",  false  ],
             [ "{+keys:1}",  false  ],
             [ "{;keys:1*}",  false  ],
             [ "?{-join|&|var,list}" , false ],
             [ "/people/{~thing}", false],
             [ "/sparql{?query){&default-graph-uri*}", false ],
-            [ "/resolution{?x, y}" , false ],
-            [ "http://example.com/home/" , false]
-            
+            [ "/resolution{?x, y}" , false ]
+
         ]
     }
 }


### PR DESCRIPTION
Negative test cases that failed when the input string did not contain any expressions have been removed. 
