### PR TITLE
Prefix modifier and exploded tests

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -114,5 +114,40 @@
             [ "{?1337*}", "?1337=leet&1337=as&1337=it&1337=can&1337=be"],
             [ "{?german*}", [ "?11=elf&12=zw%C3%B6lf", "?12=zw%C3%B6lf&11=elf"] ]
         ]
+    },
+    "Prefix modifiers and exploded": {
+        "level": 4,
+        "variables": {
+            "text": "I like octal numbers",
+            "emptyObject": {},
+            "filledObject": {
+                "composite": "true"
+            },
+            "emptyArr": [],
+            "filledArr": [1]
+        },
+        "testcases": [
+            ["{text:0}", false],
+            ["{text:08}", false],
+            ["{text:8}", "I%20like%20o"],
+            ["{text:9999}", "I%20like%20octal%20numbers"],
+            ["{text:10000}", false],
+            ["{text:1.0}", false],
+            ["{text:1e+2}", false],
+            ["{text:9876543210987654321098765432109876543210}", false],
+            ["{emptyObject:1}", ""],
+            ["{filledObject:1}", false],
+            ["{emptyArr:1}", ""],
+            ["{filledArr:1}", false],
+            ["{text:1:1}", false],
+            ["{?*}", false],
+            ["{?:1}", false],
+            ["{?a,:1}", false],
+            ["{*}", false],
+            ["{text**}", false],
+            ["{text:1*}", false],
+            ["{text*:1}", false]
+
+        ]
     }
 }


### PR DESCRIPTION
Hi there,
during refactoring of my varspec parser (cyclomatic complexity reached 20 meanwhile!) I found, that the parser misses some strange corner cases.
One was {var:011} -> my parser used the build in parseInt, which interpreted 011 as octal number and returned 9. {var:08} parsed only the 0, so the length was zero. {var:<very long int>} returned a NaN. {?} returned a varspec with an empty name and so on.
