### PR TITLE
Fix test cases for expansion of empty lists & maps

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -92,9 +92,9 @@
         "testcases":[
             [ "{/empty_list}", [ "" ] ],
             [ "{/empty_list*}", [ "" ] ],
-            [ "{?empty_list}", [ "?empty_list="] ],
+            [ "{?empty_list}", [ ""] ],
             [ "{?empty_list*}", [ "" ] ],
-            [ "{?empty_assoc}", [ "?empty_assoc=" ] ],
+            [ "{?empty_assoc}", [ "" ] ],
             [ "{?empty_assoc*}", [ "" ] ]
         ]
     },


### PR DESCRIPTION
Empty lists and maps should be treated as though they were undefined.
