### PR TITLE
Fix extended explode tests

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -126,10 +126,22 @@
             }
         },
         "testcases":[
-            [ "{?id,token,keys*}", "?id=admin&token=12345&key1=val1&key2=val2" ],
-            [ "{/id}{?token,keys*}", "/admin?token=12345&key1=val1&key2=val2" ],
-            [ "{?id,token}{&keys*}", "?id=admin&token=12345&key1=val1&key2=val2" ],
-            [ "/user{/id}{?token,tab}{&keys*}", "/user/admin?token=12345&tab=overview&key1=val1&key2=val2" ]
+            [ "{?id,token,keys*}", [
+                "?id=admin&token=12345&key1=val1&key2=val2",
+                "?id=admin&token=12345&key2=val2&key1=val1"]
+            ],
+            [ "{/id}{?token,keys*}", [
+                "/admin?token=12345&key1=val1&key2=val2",
+                "/admin?token=12345&key2=val2&key1=val1"]
+            ],
+            [ "{?id,token}{&keys*}", [
+                "?id=admin&token=12345&key1=val1&key2=val2",
+                "?id=admin&token=12345&key2=val2&key1=val1"]
+            ],
+            [ "/user{/id}{?token,tab}{&keys*}", [
+                "/user/admin?token=12345&tab=overview&key1=val1&key2=val2",
+                "/user/admin?token=12345&tab=overview&key2=val2&key1=val1"]
+            ]
         ]
     }
 }


### PR DESCRIPTION
This commit brings these tests into line with those above by providing a list of acceptable expansions, one for each possible ordering of the exploded dictionary elements.

My implementation of RFC6570 (https://github.com/SwiftScream/URITemplate) happened to fail these due to it producing the alternate ordering.