### PR TITLE
Add some tests for passing already-pct-encoded values to a + or #var #40

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -147,6 +147,7 @@
     "Additional Examples 6: Reserved Expansion":{
         "variables" : {
             "id" : "admin%2F",
+            "not_pct" : "%foo",
             "list" : ["red%25", "%2Fgreen", "blue "],
             "keys" : {
                 "key1": "val1%2F",
@@ -157,6 +158,9 @@
 			["{+id}", "admin%2F"],
 			["{#id}", "#admin%2F"],
 			["{id}", "admin%252F"],
+			["{+not_pct}", "%25foo"],
+			["{#not_pct}", "#%25foo"],
+			["{not_pct}", "%25foo"],
 			["{+list}", "red%25,%2Fgreen,blue%20"],
 			["{#list}", "#red%25,%2Fgreen,blue%20"],
 			["{list}", "red%2525,%252Fgreen,blue%20"],

--- a/extended-tests.json
+++ b/extended-tests.json
@@ -143,5 +143,26 @@
                 "/user/admin?token=12345&tab=overview&key2=val2&key1=val1"]
             ]
         ]
+    },
+    "Additional Examples 6: Reserved Expansion":{
+        "variables" : {
+            "id" : "admin%2F",
+            "list" : ["red%25", "%2Fgreen", "blue "],
+            "keys" : {
+                "key1": "val1%2F",
+                "key2": "val2%2F"
+            }
+        },
+        "testcases": [
+			["{+id}", "admin%2F"],
+			["{#id}", "#admin%2F"],
+			["{id}", "admin%252F"],
+			["{+list}", "red%25,%2Fgreen,blue%20"],
+			["{#list}", "#red%25,%2Fgreen,blue%20"],
+			["{list}", "red%2525,%252Fgreen,blue%20"],
+			["{+keys}", "key1,val1%2F,key2,val2%2F"],
+			["{#keys}", "#key1,val1%2F,key2,val2%2F"],
+			["{keys}", "key1,val1%252F,key2,val2%252F"]
+        ]
     }
 }


### PR DESCRIPTION
The RFC allows for users to pass already pct-encoded content to values for +var or #var, however the RFC doc does not contain any examples of this, and therefore the tests don't contain any.

3.2.1
   The allowed set for a given expansion depends on the expression type:
   reserved ("+") and fragment ("#") expansions allow the set of
   characters in the union of ( unreserved / reserved / pct-encoded ) to
   be passed through without pct-encoding, whereas all other expression
   types allow only unreserved characters to be passed through without
   pct-encoding.  Note that the percent character ("%") is only allowed
   as part of a pct-encoded triplet and only for reserved/fragment
   expansion: in all other cases, a value character of "%" MUST be pct-
   encoded as "%25" by variable expansion.

