### PR TITLE
Change "empty_keys" to an object, to be symmetric with "keys"

### DIFF
--- a/spec-examples-by-section.json
+++ b/spec-examples-by-section.json
@@ -17,7 +17,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -50,7 +50,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -104,7 +104,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -161,7 +161,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -203,7 +203,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
     },
     "testcases" : [
@@ -255,7 +255,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -307,7 +307,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -358,7 +358,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [
@@ -406,7 +406,7 @@
        "x"          : "1024",
        "y"          : "768",
        "empty"      : "",
-       "empty_keys" : [],
+       "empty_keys" : {},
        "undef"      : null
      },
      "testcases" : [


### PR DESCRIPTION
This shouldn't change the outcome of any tests.

This is a trivial PR that closes #28 and #31.

I don't think the the case-insensitive issue from #31 needs a fix, because it's trivial to normalize the tests to your preferred case. According to [RFC 3986 §2.1.  Percent-Encoding](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1), two URIs that vary only by the case of pct-encoded forms are the same, but the uppercase form is preferred.

Here's an example of some code to perform this:

```javascript
function normalize_pct_case(a){
  return a.replace(/%[0-9A-Fa-f]{2}/g, s => s.toUpperCase());
}
```