### PR TITLE
Reserved expansion dictionary explode alternate ordering

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -141,9 +141,18 @@
             ["{+list}", "red%25,%2Fgreen,blue%20"],
             ["{#list}", "#red%25,%2Fgreen,blue%20"],
             ["{list}", "red%2525,%252Fgreen,blue%20"],
-            ["{+keys}", "key1,val1%2F,key2,val2%2F"],
-            ["{#keys}", "#key1,val1%2F,key2,val2%2F"],
-            ["{keys}", "key1,val1%252F,key2,val2%252F"]
+            ["{+keys}", [
+                "key1,val1%2F,key2,val2%2F",
+                "key2,val2%2F,key1,val1%2F"]
+            ],
+            ["{#keys}", [
+                "#key1,val1%2F,key2,val2%2F",
+                "#key2,val2%2F,key1,val1%2F"]
+            ],
+            ["{keys}", [
+                "key1,val1%252F,key2,val2%252F",
+                "key2,val2%252F,key1,val1%252F"]
+            ]
         ]
     }
 }

--- a/extended-tests.json
+++ b/extended-tests.json
@@ -132,18 +132,18 @@
             }
         },
         "testcases": [
-			["{+id}", "admin%2F"],
-			["{#id}", "#admin%2F"],
-			["{id}", "admin%252F"],
-			["{+not_pct}", "%25foo"],
-			["{#not_pct}", "#%25foo"],
-			["{not_pct}", "%25foo"],
-			["{+list}", "red%25,%2Fgreen,blue%20"],
-			["{#list}", "#red%25,%2Fgreen,blue%20"],
-			["{list}", "red%2525,%252Fgreen,blue%20"],
-			["{+keys}", "key1,val1%2F,key2,val2%2F"],
-			["{#keys}", "#key1,val1%2F,key2,val2%2F"],
-			["{keys}", "key1,val1%252F,key2,val2%252F"]
+            ["{+id}", "admin%2F"],
+            ["{#id}", "#admin%2F"],
+            ["{id}", "admin%252F"],
+            ["{+not_pct}", "%25foo"],
+            ["{#not_pct}", "#%25foo"],
+            ["{not_pct}", "%25foo"],
+            ["{+list}", "red%25,%2Fgreen,blue%20"],
+            ["{#list}", "#red%25,%2Fgreen,blue%20"],
+            ["{list}", "red%2525,%252Fgreen,blue%20"],
+            ["{+keys}", "key1,val1%2F,key2,val2%2F"],
+            ["{#keys}", "#key1,val1%2F,key2,val2%2F"],
+            ["{keys}", "key1,val1%252F,key2,val2%252F"]
         ]
     }
 }


### PR DESCRIPTION
This change brings these tests into line with those above by providing a list of acceptable expansions, one for each possible ordering of the exploded dictionary elements.

My implementation of RFC6570 (https://github.com/SwiftScream/URITemplate) happened to fail these due to it producing the alternate ordering.