### PR TITLE
Add prefix modifier tests with multibyte characters

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -145,5 +145,24 @@
 			["{#keys}", "#key1,val1%2F,key2,val2%2F"],
 			["{keys}", "key1,val1%252F,key2,val2%252F"]
         ]
+    },
+    "Additional Examples 7: Prefix Modifiers with Multibyte Characters":{
+        "level": 4,
+        "variables" : {
+            "var" : "value",
+            "greek" : "αβγδε",
+            "currency" : "€uro",
+            "clef" : "𝄞stave"
+        },
+        "testcases": [
+            [ "{greek:1}", "%CE%B1" ],
+            [ "{greek:2}", "%CE%B1%CE%B2" ],
+            [ "{+greek:2}", "%CE%B1%CE%B2" ],
+            [ "{greek:30}", "%CE%B1%CE%B2%CE%B3%CE%B4%CE%B5" ],
+            [ "{currency:1}", "%E2%82%AC" ],
+            [ "{?currency:1}", "?currency=%E2%82%AC" ],
+            [ "{clef:1}", "%F0%9D%84%9E" ],
+            [ "{var:9999}", "value" ]
+        ]
     }
 }


### PR DESCRIPTION
RFC 6570 section 2.4.1 defines the prefix max-length as a maximum number of characters from the beginning of the value as a Unicode string, and notes that the numbering is in characters, not octets, to avoid splitting multi-octet-encoded characters. None of the existing prefix tests use a non-ASCII value, so an implementation that truncates by byte or by UTF-16 code unit passes the suite today while splitting characters mid-sequence. This adds a group covering two-, three-, and four-byte UTF-8 characters under simple, reserved, and form-style expansion, plus a max-length longer than the value and the largest grammar-valid max-length of 9999.