### PR TITLE
Add negative tests for varspec grammar boundaries

### DIFF
--- a/negative-tests.json
+++ b/negative-tests.json
@@ -50,7 +50,14 @@
             [ "/{default-graph-uri}", false ],
             [ "/sparql{?query,default-graph-uri}", false ],
             [ "/sparql{?query){&default-graph-uri*}", false ],
-            [ "/resolution{?x, y}" , false ]
+            [ "/resolution{?x, y}", false ],
+            [ "{var:0}", false ],
+            [ "{var:01}", false ],
+            [ "{var:10000}", false ],
+            [ "{var:}", false ],
+            [ "{x.}", false ],
+            [ "{x..y}", false ],
+            [ "{%2x}", false ]
 
         ]
     }


### PR DESCRIPTION
RFC 6570 section 2.4.1 defines max-length as %x31-39 0*3DIGIT, so a prefix length must start with a non-zero digit and has at most four digits, making {var:0}, {var:01}, {var:10000}, and {var:} invalid. Section 2.3 defines varname as varchar *( ["."] varchar ), so a variable name cannot end with a dot or contain consecutive dots, and a pct-encoded varchar requires two hex digits, making {x.}, {x..y}, and {%2x} invalid. The existing negative tests only cover a non-numeric prefix length and a prefix combined with explode, so none of these grammar boundaries are currently exercised.