### PR TITLE
Add literal encoding tests for non-ASCII and pct-encoded literals

### DIFF
--- a/extended-tests.json
+++ b/extended-tests.json
@@ -164,5 +164,16 @@
             [ "{clef:1}", "%F0%9D%84%9E" ],
             [ "{var:9999}", "value" ]
         ]
+    },
+    "Additional Examples 8: Literal Encoding":{
+        "level": 1,
+        "variables" : {
+            "var" : "value"
+        },
+        "testcases": [
+            [ "café/{var}", "caf%C3%A9/value" ],
+            [ "x%20y/{var}", "x%20y/value" ],
+            [ "x%20y{var}z%20w", "x%20yvaluez%20w" ]
+        ]
     }
 }


### PR DESCRIPTION
RFC 6570 section 3.1 requires literal characters that are not allowed in a URI to be converted to their UTF-8 encoding and then percent-encoded, while section 2.1 allows ucschar literals and pct-encoded triplets in templates, which are copied through unchanged. Every template in the suite is currently plain ASCII outside expressions, so an implementation that copies literals verbatim and produces an invalid URI still passes. This adds a small group covering a non-ASCII literal and pct-encoded triplets in literal text.

FYI, I named this additional examples 8 and not 7 because of #65.